### PR TITLE
Copy bsp_specs of RISC-V generic BSP into the proper location.

### DIFF
--- a/c/src/lib/libbsp/riscv32/Makefile.am
+++ b/c/src/lib/libbsp/riscv32/Makefile.am
@@ -2,7 +2,13 @@ ACLOCAL_AMFLAGS = -I ../../../aclocal
 ## Descend into the @RTEMS_BSP_FAMILY@ directory
 ## Currently, the shared directory is not explicitly
 ## added but it is present in the source tree.
-SUBDIRS = @RTEMS_BSP_FAMILY@
+
+
+_SUBDIRS = @RTEMS_BSP_FAMILY@
+
+include_bspdir = $(includedir)/bsp
+include_bsp_HEADERS = shared/include/linker-symbols.h
+
 include $(srcdir)/preinstall.am
 include $(top_srcdir)/../../../automake/subdirs.am
 include $(top_srcdir)/../../../automake/local.am

--- a/c/src/lib/libbsp/riscv32/preinstall.am
+++ b/c/src/lib/libbsp/riscv32/preinstall.am
@@ -5,3 +5,20 @@ $(srcdir)/preinstall.am: Makefile.am
 	$(AMPOLISH3) $(srcdir)/Makefile.am > $(srcdir)/preinstall.am
 endif
 
+PREINSTALL_DIRS =
+DISTCLEANFILES = $(PREINSTALL_DIRS)
+
+all-am: $(PREINSTALL_FILES)
+
+PREINSTALL_FILES =
+CLEANFILES = $(PREINSTALL_FILES)
+
+$(PROJECT_INCLUDE)/bsp/$(dirstamp):
+	@$(MKDIR_P) $(PROJECT_INCLUDE)/bsp
+	@: > $(PROJECT_INCLUDE)/bsp/$(dirstamp)
+PREINSTALL_DIRS += $(PROJECT_INCLUDE)/bsp/$(dirstamp)
+
+$(PROJECT_INCLUDE)/bsp/linker-symbols.h: shared/include/linker-symbols.h $(PROJECT_INCLUDE)/bsp/$(dirstamp)
+	$(INSTALL_DATA) $< $(PROJECT_INCLUDE)/bsp/linker-symbols.h
+PREINSTALL_FILES += $(PROJECT_INCLUDE)/bsp/linker-symbols.h
+

--- a/c/src/lib/libbsp/riscv32/riscv_generic/Makefile.am
+++ b/c/src/lib/libbsp/riscv32/riscv_generic/Makefile.am
@@ -17,7 +17,7 @@ dist_project_lib_DATA = bsp_specs
 ###############################################################################
 
 include_HEADERS = include/bsp.h
-include_HEADERS += include/tm27.h
+include_HEADERS += ../../shared/include/tm27.h
 include_HEADERS += ../../shared/include/coverhd.h
 
 nodist_include_bsp_HEADERS = ../../shared/include/bootcard.h
@@ -57,10 +57,10 @@ libbsp_a_SOURCES += ../../shared/bspstart.c
 # Shared
 libbsp_a_SOURCES += ../../shared/bootcard.c
 libbsp_a_SOURCES += ../../shared/bspclean.c
-libbsp_a_SOURCES += ../../shared/bsplibc.c
-libbsp_a_SOURCES += ../../shared/bsppost.c
+#libbsp_a_SOURCES += ../../shared/bsplibc.c
+#libbsp_a_SOURCES += ../../shared/bsppost.c
 libbsp_a_SOURCES += ../../shared/bsppredriverhook.c
-libbsp_a_SOURCES += ../../shared/bsppretaskinghook.c
+#libbsp_a_SOURCES += ../../shared/bsppretaskinghook.c
 libbsp_a_SOURCES += ../../shared/gnatinstallhandler.c
 libbsp_a_SOURCES += ../../shared/sbrk.c
 libbsp_a_SOURCES += ../../shared/src/stackalloc.c

--- a/c/src/lib/libbsp/riscv32/riscv_generic/bsp_specs
+++ b/c/src/lib/libbsp/riscv32/riscv_generic/bsp_specs
@@ -10,4 +10,4 @@
 %{!qrtems: %(old_link)} %{qrtems: -dc -dp -N}
 
 *endfile:
-%{!qrtems: *(old_endfiles)} %{qrtems: crtend.o%s crtn.o%s }
+%{!qrtems: %(old_endfiles)} %{qrtems: crtend.o%s crtn.o%s }

--- a/c/src/lib/libbsp/riscv32/riscv_generic/configure.ac
+++ b/c/src/lib/libbsp/riscv32/riscv_generic/configure.ac
@@ -5,7 +5,7 @@
 # @brief Configure script of LibBSP for riscv_spike BSP.
 #
 
-AC_PREREQ(2.69)
+AC_PREREQ([2.69])
 AC_INIT([rtems-c-src-lib-libbsp-riscv_generic],[_RTEMS_VERSION],[http://www.rtems.org/bugzilla])
 AC_CONFIG_SRCDIR([bsp_specs])
 RTEMS_TOP(../../../../../..)

--- a/c/src/lib/libbsp/riscv32/riscv_generic/preinstall.am
+++ b/c/src/lib/libbsp/riscv32/riscv_generic/preinstall.am
@@ -46,7 +46,7 @@ $(PROJECT_INCLUDE)/bsp.h: include/bsp.h $(PROJECT_INCLUDE)/$(dirstamp)
 	$(INSTALL_DATA) $< $(PROJECT_INCLUDE)/bsp.h
 PREINSTALL_FILES += $(PROJECT_INCLUDE)/bsp.h
 
-$(PROJECT_INCLUDE)/tm27.h: include/tm27.h $(PROJECT_INCLUDE)/$(dirstamp)
+$(PROJECT_INCLUDE)/tm27.h: ../../shared/include/tm27.h $(PROJECT_INCLUDE)/$(dirstamp)
 	$(INSTALL_DATA) $< $(PROJECT_INCLUDE)/tm27.h
 PREINSTALL_FILES += $(PROJECT_INCLUDE)/tm27.h
 

--- a/c/src/lib/libbsp/riscv32/riscv_generic/start/start.S
+++ b/c/src/lib/libbsp/riscv32/riscv_generic/start/start.S
@@ -43,7 +43,7 @@ PUBLIC(_start)
 
 .section .vector, "ax"
 /* 0x100 user-level trap */
-  mrts
+  #mrts
   #la s0, 0xF0000000
   #jr  s0
 /* 0x140 supervisor level trap */
@@ -215,4 +215,4 @@ trap_entry:
 
   addi sp, sp, 272
 
-  eret
+  mret


### PR DESCRIPTION
This patch makes a build proceed further. 